### PR TITLE
Fix: incorrect os name append

### DIFF
--- a/src/goal/mojangJava.ts
+++ b/src/goal/mojangJava.ts
@@ -49,7 +49,7 @@ function* flattenInfo(info: PistonJavaRuntimeInfo): Generator<FullRuntimeInfo> {
 }
 function transformRuntime(entry: FullRuntimeInfo): VersionFileRuntime {
 	const os = entry.os === "mac-os" || !entry.os.includes("-")
-		? entry.os + "x64"
+		? entry.os + "-x64"
 		: entry.os;
 
 	return {


### PR DESCRIPTION
Fix incorrect mojang java `runtimeOS` field with `linux`.
It should be `linux-x64`, but it is `linuxx64`.
- Incorrect one: `linuxx64` - https://raw.githubusercontent.com/MCSRLauncher/meta/13303ccdf03bc2366b281ed7eaba91d58ce1dff8/output/net.minecraft.java/java21.json
- Correct one: `linux-x64` - https://meta.prismlauncher.org/v1/net.minecraft.java/java21.json