### PR TITLE
Add logging info in minecraft version

### DIFF
--- a/src/goal/minecraft.ts
+++ b/src/goal/minecraft.ts
@@ -69,6 +69,7 @@ function transformVersion(version: PistonVersion): VersionOutput {
 			name: `com.mojang:minecraft:${version.id}:client`,
 			downloads: { artifact: version.downloads.client }
 		},
+		logging: version.logging?.client,
 		assetIndex: version.assetIndex,
 		libraries: libraries.map(transformPistonLibrary),
 	};

--- a/src/schema/format/v1/versionFile.ts
+++ b/src/schema/format/v1/versionFile.ts
@@ -1,4 +1,4 @@
-import { PistonArtifact, PistonLibrary, type PistonAssetIndexRef } from "#schema/pistonMeta/pistonVersion.ts";
+import { PistonArtifact, PistonLibrary, type PistonLoggingAsset, type PistonAssetIndexRef } from "#schema/pistonMeta/pistonVersion.ts";
 
 export interface VersionFile {
 	uid: string;
@@ -23,6 +23,7 @@ export interface VersionFile {
 	minecraftArguments?: string;
 
 	mainJar?: VersionFileLibrary;
+	logging?: PistonLoggingAsset;
 	libraries?: VersionFileLibrary[];
 	mavenFiles?: VersionFileLibrary[];
 	assetIndex?: PistonAssetIndexRef;

--- a/src/schema/pistonMeta/pistonVersion.ts
+++ b/src/schema/pistonMeta/pistonVersion.ts
@@ -68,6 +68,14 @@ export const PistonAssetIndexRef = z.object({
 
 export type PistonAssetIndexRef = z.output<typeof PistonAssetIndexRef>;
 
+export const PistonLoggingAsset = z.object({
+	argument: z.string(),
+	file: PistonArtifact.omit({ path: true }).extend({ id: z.string() }),
+	type: z.string(),
+});
+
+export type PistonLoggingAsset = z.output<typeof PistonLoggingAsset>;
+
 
 export const PistonArgument = z.union([
 	z.string(),
@@ -93,11 +101,7 @@ export const PistonVersion = z.object({
 	}).optional(),
 	libraries: z.array(PistonLibrary),
 	logging: z.object({
-		client: z.object({
-			argument: z.string(),
-			file: PistonArtifact.omit({ path: true }).extend({ id: z.string() }),
-			type: z.string(),
-		}).optional(),
+		client: PistonLoggingAsset.optional(),
 	}).optional(),
 	mainClass: z.string().nullable().optional().transform(x => x ?? undefined),
 	minecraftArguments: z.string().optional(),


### PR DESCRIPTION
`logging` field in minecraft version is missing, compared with prism meta.